### PR TITLE
Change run_all example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ rules = [
     ]},
       { "all": [
         {  "name": "current_month",
-          "operator": "equals",
+          "operator": "equal_to",
           "value": "December",
         },
         { "name": "goes_well_with",


### PR DESCRIPTION
Looks like the `run_all` api changed, but the README never got updated. This PR fixes that.
