### PR TITLE
Allow rule decorators to be used without args

### DIFF
--- a/business_rules/variables.py
+++ b/business_rules/variables.py
@@ -41,12 +41,18 @@ def rule_variable(field_type, label=None, options=None, cache_result=True):
     return wrapper
 
 def numeric_rule_variable(label=None):
+    if callable(label):
+        return rule_variable(NumericType)(label)
     return rule_variable(NumericType, label=label)
 
 def string_rule_variable(label=None):
+    if callable(label):
+        return rule_variable(StringType)(label)
     return rule_variable(StringType, label=label)
 
 def boolean_rule_variable(label=None):
+    if callable(label):
+        return rule_variable(BooleanType)(label)
     return rule_variable(BooleanType, label=label)
 
 def select_rule_variable(label=None, options=None):

--- a/business_rules/variables.py
+++ b/business_rules/variables.py
@@ -40,20 +40,21 @@ def rule_variable(field_type, label=None, options=None, cache_result=True):
         return func
     return wrapper
 
-def numeric_rule_variable(label=None):
+
+def _rule_variable_wrapper(field_type, label):
     if callable(label):
-        return rule_variable(NumericType)(label)
-    return rule_variable(NumericType, label=label)
+        # Decorator is being called with no args, label is actually the decorated func
+        return rule_variable(field_type)(label)
+    return rule_variable(field_type, label=label)
+
+def numeric_rule_variable(label=None):
+    return _rule_variable_wrapper(NumericType, label)
 
 def string_rule_variable(label=None):
-    if callable(label):
-        return rule_variable(StringType)(label)
-    return rule_variable(StringType, label=label)
+    return _rule_variable_wrapper(StringType, label)
 
 def boolean_rule_variable(label=None):
-    if callable(label):
-        return rule_variable(BooleanType)(label)
-    return rule_variable(BooleanType, label=label)
+    return _rule_variable_wrapper(BooleanType, label)
 
 def select_rule_variable(label=None, options=None):
     return rule_variable(SelectType, label=label, options=options)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -69,32 +69,59 @@ class RuleVariableTests(TestCase):
         self.assertEqual(foo_func(), 1)
         foo = 2
         self.assertEqual(foo_func(), 2)
-    
+
     ###
     ### rule_variable wrappers for each variable type
     ###
 
     def test_numeric_rule_variable(self):
 
-        @numeric_rule_variable()
+        @numeric_rule_variable('My Label')
         def numeric_var(): pass
-        
+
+        self.assertTrue(getattr(numeric_var, 'is_rule_variable'))
+        self.assertEqual(getattr(numeric_var, 'field_type'), NumericType)
+        self.assertEqual(getattr(numeric_var, 'label'), 'My Label')
+
+    def test_numeric_rule_variable_no_parens(self):
+
+        @numeric_rule_variable
+        def numeric_var(): pass
+
         self.assertTrue(getattr(numeric_var, 'is_rule_variable'))
         self.assertEqual(getattr(numeric_var, 'field_type'), NumericType)
 
     def test_string_rule_variable(self):
 
-        @string_rule_variable()
+        @string_rule_variable(label='My Label')
         def string_var(): pass
-        
+
         self.assertTrue(getattr(string_var, 'is_rule_variable'))
         self.assertEqual(getattr(string_var, 'field_type'), StringType)
-    
+        self.assertEqual(getattr(string_var, 'label'), 'My Label')
+
+    def test_string_rule_variable_no_parens(self):
+
+        @string_rule_variable
+        def string_var(): pass
+
+        self.assertTrue(getattr(string_var, 'is_rule_variable'))
+        self.assertEqual(getattr(string_var, 'field_type'), StringType)
+
     def test_boolean_rule_variable(self):
 
-        @boolean_rule_variable()
+        @boolean_rule_variable(label='My Label')
         def boolean_var(): pass
-        
+
+        self.assertTrue(getattr(boolean_var, 'is_rule_variable'))
+        self.assertEqual(getattr(boolean_var, 'field_type'), BooleanType)
+        self.assertEqual(getattr(boolean_var, 'label'), 'My Label')
+
+    def test_boolean_rule_variable_no_parens(self):
+
+        @boolean_rule_variable
+        def boolean_var(): pass
+
         self.assertTrue(getattr(boolean_var, 'is_rule_variable'))
         self.assertEqual(getattr(boolean_var, 'field_type'), BooleanType)
 
@@ -103,7 +130,7 @@ class RuleVariableTests(TestCase):
         options = {'foo':'bar'}
         @select_rule_variable(options=options)
         def select_var(): pass
-        
+
         self.assertTrue(getattr(select_var, 'is_rule_variable'))
         self.assertEqual(getattr(select_var, 'field_type'), SelectType)
         self.assertEqual(getattr(select_var, 'options'), options)
@@ -113,7 +140,7 @@ class RuleVariableTests(TestCase):
         options = {'foo':'bar'}
         @select_multiple_rule_variable(options=options)
         def select_multiple_var(): pass
-        
+
         self.assertTrue(getattr(select_multiple_var, 'is_rule_variable'))
         self.assertEqual(getattr(select_multiple_var, 'field_type'), SelectMultipleType)
         self.assertEqual(getattr(select_multiple_var, 'options'), options)


### PR DESCRIPTION
I've seen people with this issue a couple times, most recently: https://github.com/venmo/business-rules/issues/16

This PR will allow variable decorators to be used with or without params/parens, like so:

```python
@string_rule_variable(label="My variable!")
def my_var(self):
    return "foo"

### OR

@string_rule_variable
def my_var(self):
    return "foo"
```