### PR TITLE
Handling possible database null value from boolean field

### DIFF
--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -142,7 +142,7 @@ class BooleanType(BaseType):
     name = "boolean"
 
     def _assert_valid_value_and_cast(self, value):
-        if type(value) != bool:
+        if type(value) != bool and value is not None:
             raise AssertionError("{0} is not a valid boolean type".
                                  format(value))
         return value


### PR DESCRIPTION
In some case the support for a null value could be enabled on a boolean field and i think the `None` object is just like an empty string: `False` on the eyes of python. So there not much reason to throw an exception like that on a `None` value.