### PR TITLE
Support condition variables with keyword arguments

### DIFF
--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -51,10 +51,11 @@ def check_condition(condition, defined_variables):
     object must have a variable defined for any variables in this condition.
     """
     name, op, value = condition['name'], condition['operator'], condition['value']
-    operator_type = _get_variable_value(defined_variables, name)
+    method_kwargs = condition.get('kwargs', {})
+    operator_type = _get_variable_value(defined_variables, name, method_kwargs)
     return _do_operator_comparison(operator_type, op, value)
 
-def _get_variable_value(defined_variables, name):
+def _get_variable_value(defined_variables, name, method_kwargs):
     """ Call the function provided on the defined_variables object with the
     given name (raise exception if that doesn't exist) and casts it to the
     specified type.
@@ -65,7 +66,7 @@ def _get_variable_value(defined_variables, name):
         raise AssertionError("Variable {0} is not defined in class {1}".format(
                 name, defined_variables.__class__.__name__))
     method = getattr(defined_variables, name, fallback)
-    val = method()
+    val = method(**method_kwargs)
     return method.field_type(val)
 
 def _do_operator_comparison(operator_type, operator_name, comparison_value):

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -1,5 +1,5 @@
 from business_rules import engine
-from business_rules.variables import BaseVariables
+from business_rules.variables import BaseVariables, boolean_rule_variable
 from business_rules.operators import StringType
 from business_rules.actions import BaseActions
 
@@ -171,6 +171,23 @@ class EngineTests(TestCase):
             self.assertTrue(result)
             string_type.contains.assert_called_once_with('its mocked')
 
+    ###
+    ### Keyword arguments
+    ###
+    def test_kwargs_passed_into_variable_method(self):
+        class TestVariables(BaseVariables):
+            @boolean_rule_variable
+            def test_eq_one(self, arg1=0):
+                return arg1 == 1
+
+        conditions = {'all': [
+            {'name': 'test_eq_one', 'operator': 'is_false', 'value': True},
+            {'name': 'test_eq_one', 'operator': 'is_false', 'value': True, 'kwargs': {'arg1': 2}},
+            {'name': 'test_eq_one', 'operator': 'is_true', 'value': True, 'kwargs': {'arg1': 1}}]}
+        tv = TestVariables()
+
+        result = engine.check_conditions_recursively(conditions, tv)
+        self.assertTrue(result)
 
     ###
     ### Actions


### PR DESCRIPTION
The motivation for this feature comes from a real world use case of this
library. We need to configure different rules per customer, and it makes
the most sense to leverage the Variables and Action objects that already exist.

Introducing kwargs to variable methods allows more customizability.
Defaults are set in code and configured values are used at runtime
if present. We opt for this approach over passing in parameters when
creating the Variables object because there are many Variables methods
which share common keyword args but must be configured independently.
Updating the business-rules library creates a cleaner interface than
managing dozens of verbose options during class instantiation.

This feature is backwards compatible with existing rules.